### PR TITLE
Fix for: test clients don't use command line arguments

### DIFF
--- a/test/backend.js
+++ b/test/backend.js
@@ -4,7 +4,8 @@ var program = require('commander');
 
 program
     .option('-p, --port <port>', 'Server IP port', parseInt,9000)
-    .option('-i, --ip <ip>', 'Server IP address','127.0.0.1');
+    .option('-i, --ip <ip>', 'Server IP address','127.0.0.1')
+    .parse(process.argv);
 
 var connection = new autobahn.Connection({
    url: 'ws://' + program.ip + ':' + program.port,
@@ -35,7 +36,7 @@ connection.onopen = function (session) {
    function echo(args,kwargs) {
      console.log("args",args,"kwargs",kwargs);
      return new autobahn.Result(args, kwargs);
-   };
+   }
 
    session.register('com.echoservice.echo', echo).then(
       function (registration) {

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -4,7 +4,8 @@ var program = require('commander');
 
 program
     .option('-p, --port <port>', 'Server IP port', parseInt,9000)
-    .option('-i, --ip <ip>', 'Server IP address','127.0.0.1');
+    .option('-i, --ip <ip>', 'Server IP address','127.0.0.1')
+    .parse(process.argv);
 
 var connection = new autobahn.Connection({
    url: 'ws://' + program.ip + ':' + program.port,


### PR DESCRIPTION
The call to .parse() was missing in commander's program options, so parameters passed on the command line were not being picked up.
