### PR TITLE
Fix undefined variable  in handlers.

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -145,6 +145,7 @@ handlers[WAMP.SUBSCRIBE] = function(session, args) {
     var options = args.shift();
     var topicUri = args.shift();
     args = args || [];
+    var msg;
 
     var eventCallback = function(publicationId, args, kwargs) {
         log.trace('eventCallback', publicationId, args, kwargs);
@@ -177,6 +178,7 @@ handlers[WAMP.UNSUBSCRIBE] = function(session, args) {
     var subsid = args.shift();
     var topicUri = session.unsubscribe(subsid);
     args = args || [];
+    var msg;
 
     if (typeof this.gettopic(topicUri) === 'undefined') {
 	msg = [ WAMP.ERROR, WAMP.UNSUBSCRIBE, requestId, {},


### PR DESCRIPTION
The variable `msg` was used without being defined, leaking into the global scope.
