### PR TITLE
disableProtocolCheck option and close() method

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -16,23 +16,26 @@ util.inherits(Router, eventEmitter);
 
 function Router(options) {
     var _options = options || {};
-    // We need to verify that the subprotocol is wamp.2.json
-    var cb = _options.handleProtocols;
-    _options.handleProtocols = function (protocols, callback) {
-        var i=0;
-        var result = false;
-        while(i < protocols.length && result === false) {
-            result = (protocols[i] == "wamp.2.json");
-            i++;
-        }
-        if (result && typeof cb == 'function') {
-            // If a handleProtocol function was provided by the
-            // calling script, just filter out the results
-            cb([protocols[i-1]], callback);
-        } else {
-            callback(result, result ? protocols[i-1] : null);
-        }
-    };
+
+    if ( !_options.disableProtocolCheck ) {
+        // We need to verify that the subprotocol is wamp.2.json
+        var cb = _options.handleProtocols;
+        _options.handleProtocols = function (protocols, callback) {
+            var i=0;
+            var result = false;
+            while(i < protocols.length && result === false) {
+                result = (protocols[i] == "wamp.2.json");
+                i++;
+            }
+            if (result && typeof cb == 'function') {
+                // If a handleProtocol function was provided by the
+                // calling script, just filter out the results
+                cb([protocols[i-1]], callback);
+            } else {
+                callback(result, result ? protocols[i-1] : null);
+            }
+        };
+    }
     var _rpcs = {};
     var _pending = {};
     var _sessions = {};

--- a/lib/router.js
+++ b/lib/router.js
@@ -56,6 +56,10 @@ function Router(options) {
         });
     }.bind(this));
 
+    this.close = function() {
+        _wss.close();
+    };
+
     // RPC Management
     this.getrpc = function(uri) {
         return _rpcs[uri];


### PR DESCRIPTION
Because the Tessel implementation of WAMP in `wamp-tessel` does not (cannot, apparently) pass the protocol of "wamp.2.json" during websocket connection, I added a flag to the options disable the protocol check. This is similar to what has been done in crossbar.io itself (see http://crossbar.io/docs/WebSocket-Options/) 

I've also added a close() method that can close the underlying websocket server. This is necessary if you need to spin up one instance after another on the same port, for example while going through test cases.