### PR TITLE
Fix router-embedded RPC example

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -52,5 +52,5 @@ app.on('Publish', onPublish);
 
 app.regrpc('wamp.rt.foo', function(id,args) {
     console.log('called with ' + args);
-    app.resrpc(id,["bar", "bar2"], {"key1": "bar1", "key2": "bar2"});
+    app.resrpc(id,null,[["bar", "bar2"], {"key1": "bar1", "key2": "bar2"}]);
 });


### PR DESCRIPTION
The router-embedded RPC example isn't working because the second argument of resrpc() should be the error object, and not an array of arguments.