### PR TITLE
Send error message to client

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -92,7 +92,7 @@ handlers[WAMP.CALL] = function (session, args) {
                 WAMP.ERROR,
                 WAMP.CALL,
                 callId,
-                {},
+                err,
                 "wamp.error.callee_failure"
             ];
             session.send(msg);


### PR DESCRIPTION
I believe that if you returned an error as a response to a call, you should be able to read the error on the client