### PR TITLE
Arguments are being passed as an array

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -85,7 +85,7 @@ handlers[WAMP.CALL] = function (session, args) {
     var callId = args.shift();
     var options = args.shift();
     var procUri = args.shift();
-    args = args || [];
+    args = args.shift() || [];
     var resultCallback = function(err, args) {
         if (err) {
             var msg = [


### PR DESCRIPTION
The complete array of arguments are being passed instead of each position as an argument.

instead of  fn.apply(this, [arg1, arg2, arg3]) 
it was sending fn.apply(this, [[arg1, arg2, arg3]])